### PR TITLE
fixing typo around softPwmWrite binding

### DIFF
--- a/wiringpi2.py
+++ b/wiringpi2.py
@@ -674,7 +674,7 @@ class GPIO(object):
   def softPwmCreate(self,*args):
     return softPwmCreate(*args)
   def softPwmWrite(self,*args):
-    return sofPwmWrite(*args)
+    return softPwmWrite(*args)
 
   def softToneCreate(self,*args):
     return softToneCreate(*args)


### PR DESCRIPTION
Looks like a minor typo around soft PWMs. Only came up because I'm using this in OO rather than Arduino-style, I suspect.
