### PR TITLE
Made the README examples work with Python compilers / fixed syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Build with gcc version 4.6.3 (Debian 4.6.3-14+rpi1)
 Built against Python 2.7.2, Python 3.2.3
 
 **Prerequisites:**
-You must have python-dev and python-setuptools installed
+You **must** have python-dev and python-setuptools installed
 If you manually rebuild the bindings with swig -python wiringpi.i
 
 YOU MUST FIRST INSTALL WIRINGPI2!!
@@ -35,11 +35,11 @@ Description incoming!
 **Usage:**
 
 	import wiringpi2
-	wiringpi2.wiringPiSetup // For sequential pin numbering, one of these MUST be called before using IO functions
+	wiringpi2.wiringPiSetup() # For sequential pin numbering, one of these MUST be called before using IO functions
 	OR
-	wiringpi2.wiringPiSetupSys // For /sys/class/gpio with GPIO pin numbering
+	wiringpi2.wiringPiSetupSys() # For /sys/class/gpio with GPIO pin numbering
 	OR
-	wiringpi2.wiringPiSetupGpio // For GPIO pin numbering
+	wiringpi2.wiringPiSetupGpio() # For GPIO pin numbering
 
 Setting up IO expanders (This example was tested on a quick2wire board with one digital IO expansion board connected via I2C):
 
@@ -49,9 +49,9 @@ Setting up IO expanders (This example was tested on a quick2wire board with one 
 
 **General IO:**
 
-	wiringpi2.pinMode(1,1) // Set pin 1 to output
-	wiringpi2.digitalWrite(1,1) // Write 1 HIGH to pin 1
-	wiringpi2.digitalRead(1) // Read pin 1
+	wiringpi2.pinMode(1,1) # Set pin 1 to output
+	wiringpi2.digitalWrite(1,1) # Write 1 HIGH to pin 1
+	wiringpi2.digitalRead(1) # Read pin 1
 
 **Setting up a peripheral:**
 WiringPi2 supports expanding your range of available "pins" by setting up a port expander. The implementation details of
@@ -69,13 +69,13 @@ Hook a speaker up to your Pi and generate music with softTone. Also useful for g
 
 **Bit shifting:**
 
-	wiringpi2.shiftOut(1,2,0,123) // Shift out 123 (b1110110, byte 0-255) to data pin 1, clock pin 2
+	wiringpi2.shiftOut(1,2,0,123) # Shift out 123 (b1110110, byte 0-255) to data pin 1, clock pin 2
 
 **Serial:**
 
-	serial = wiringpi2.serialOpen('/dev/ttyAMA0',9600) // Requires device/baud and returns an ID
+	serial = wiringpi2.serialOpen('/dev/ttyAMA0',9600) # Requires device/baud and returns an ID
 	wiringpi2.serialPuts(serial,"hello")
-	wiringpi2.serialClose(serial) // Pass in ID
+	wiringpi2.serialClose(serial) # Pass in ID
 
 **Full details at:**
 http://www.wiringpi.com


### PR DESCRIPTION
The current version doesn't work out of the box with Python compilers due to wrong comment marks (// instead of #). Also, there were some brackets missing preventing it from working right away.
