### PR TITLE
Fix wiringPiSPIDataRW so that it will return value read from SPI bus.

### DIFF
--- a/wiringpi.i
+++ b/wiringpi.i
@@ -115,6 +115,10 @@ extern uint8_t shiftIn        (uint8_t dPin, uint8_t cPin, uint8_t order);
       $2 = PyString_Size($input);
 };
 
+%typemap(argout) (unsigned char *data) {
+      $result = SWIG_Python_AppendOutput($result, PyString_FromStringAndSize((char *) $1, result));
+};
+
 int wiringPiSPIGetFd  (int channel) ;
 int wiringPiSPIDataRW (int channel, unsigned char *data, int len) ;
 int wiringPiSPISetup  (int channel, int speed) ;

--- a/wiringpi_wrap.c
+++ b/wiringpi_wrap.c
@@ -4398,6 +4398,9 @@ SWIGINTERN PyObject *_wrap_wiringPiSPIDataRW(PyObject *SWIGUNUSEDPARM(self), PyO
   }
   result = (int)wiringPiSPIDataRW(arg1,arg2,arg3);
   resultobj = SWIG_From_int((int)(result));
+  {
+    resultobj = SWIG_Python_AppendOutput(resultobj, PyString_FromStringAndSize((char *) arg2, result));
+  }
   return resultobj;
 fail:
   return NULL;


### PR DESCRIPTION
I found that the way wiringPiSPIDataRW was implemented in SWIG did not provide a way for the value read from the SPI bus to be returned, so I fixed it.