### PR TITLE
Once again fix wiringPiSPIDataRW so that it will return value read from SPI bus.

### DIFF
--- a/wiringpi_wrap.c
+++ b/wiringpi_wrap.c
@@ -6743,6 +6743,9 @@ SWIGINTERN PyObject *_wrap_wiringPiSPIDataRW(PyObject *SWIGUNUSEDPARM(self), PyO
   }
   result = (int)wiringPiSPIDataRW(arg1,arg2,arg3);
   resultobj = SWIG_From_int((int)(result));
+  {
+    resultobj = SWIG_Python_AppendOutput(resultobj, PyString_FromStringAndSize((char *) arg2, result));
+  }
   return resultobj;
 fail:
   return NULL;


### PR DESCRIPTION
Correct changes already in in wiringpi.i, but missing from wiringpi_wrap.c. Just regenerating this file with swig fixed the issue.

Redoes what was originally fixed in pull request #17. Somehow the upgrade to the new version of wiringpi2 stomped on this change.